### PR TITLE
Use the system-installed RapidJSON libraries by default

### DIFF
--- a/dep/rapidjson/CMakeLists.txt
+++ b/dep/rapidjson/CMakeLists.txt
@@ -1,4 +1,14 @@
-# rapidjason: v1.1.0 (https://github.com/miloyip/rapidjson)
+find_package(RapidJSON)
+
 add_library(gelfcpp_rapidjson INTERFACE)
-target_include_directories(gelfcpp_rapidjson INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/rapidjson/include)
+
+if (RapidJSON_FOUND)
+    message(STATUS "gelfcpp_rapidjson: Using System rapidjson")
+    target_include_directories(gelfcpp_rapidjson INTERFACE ${RapidJSON_INCLUDE_DIRS})
+else()
+    # rapidjason: v1.1.0 (https://github.com/miloyip/rapidjson)
+    message(STATUS "gelfcpp_rapidjson: Using local rapidjson")
+    target_include_directories(gelfcpp_rapidjson INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/rapidjson/include)
+endif()
+
 target_compile_definitions(gelfcpp_rapidjson INTERFACE -DRAPIDJSON_HAS_STDSTRING=1)


### PR DESCRIPTION
We use RapidJSON ourselves in our project and use the system-installed development packages on Debian 10.

This PR makes CMake search for the system-installed development packages.
When available, they will be used. If not, the local shipped version will be used.

**Note**: *I would also suggest to include the local shipped versions by **Git submodule** instead of a "copy" of the code.*