### PR TITLE
Add required link dependency to `Threads::Threads`

### DIFF
--- a/dep/boost/CMakeLists.txt
+++ b/dep/boost/CMakeLists.txt
@@ -4,7 +4,20 @@ endif()
 
 find_package(Boost REQUIRED system ${additional_libraries})
 
+# The Boost system and iostreams (binary) libraries
+# depend on pthreads.
+#
+# Since Boost::system is not "required", we need
+# to add Threads::Threads dependencies ourselves.
+#
+# See also https://stackoverflow.com/a/29871891
+# For systems with multiple thread libraries (cmake < 3.14):
+set(CMAKE_THREAD_PREFER_PTHREAD ON)
+# The use of the -pthread compiler and linker flag is prefered:
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 add_library(gelfcpp_boost INTERFACE)
 target_include_directories(gelfcpp_boost INTERFACE ${Boost_INCLUDE_DIRS})
-target_link_libraries(gelfcpp_boost INTERFACE ${Boost_LIBRARIES})
+target_link_libraries(gelfcpp_boost INTERFACE ${Boost_LIBRARIES} Threads::Threads)
 target_compile_definitions(gelfcpp_boost INTERFACE -DBOOST_DATE_TIME_NO_LIB -DBOOST_REGEX_NO_LIB)


### PR DESCRIPTION
The `FindBoost.cmake` from CMake does not link to `Threads::Threads`, except when requiring the `Boost::threads` module.

When the gelfcpp library does not link to `Threads::Threads`, we got linker errors for `pthread_join@@GLIBC_2.2.5`.
This dependency is probably introduced by using `io_service` (i.e. `io_context`) headers from Boost 1.67.

Note that the `Boost::system` and `Boost::iostreams` (binary) libraries itself seem to be linked properly to `pthread`.
