### PR TITLE
Fix some build issues

### DIFF
--- a/include/gelfcpp/GelfMessage.hpp
+++ b/include/gelfcpp/GelfMessage.hpp
@@ -32,9 +32,10 @@ class GelfMessage
         std::string field;
 
         template<typename T>
-        void operator=(T&& value)
+        FieldSetter& operator=(T&& value)
         {
             owner.SetField(field, std::forward<T>(value));
+            return *this;
         }
     };
 

--- a/include/gelfcpp/GelfMessage.hpp
+++ b/include/gelfcpp/GelfMessage.hpp
@@ -26,11 +26,24 @@ class GelfMessage
 {
     friend struct detail::DocumentAccessor;
 
+#ifdef __GNUC__
+// RAPIDJSON_DIAG_OFF(effc++)
+#define RAPIDJSON_DIAG_WARNING(x) \
+    RAPIDJSON_DIAG_PRAGMA(warning RAPIDJSON_STRINGIFY(RAPIDJSON_JOIN(-W,x)))
+// ! FIXME - Avoid error on GCC 8.3.0 when `-Werror=effc++` is active !
+RAPIDJSON_DIAG_WARNING(effc++)
+#endif // __GNUC__
+
     struct FieldSetter
     {
         GelfMessage& owner;
         std::string field;
 
+        // 
+        // ! FIXME - Still warning/error on `-Weffc++` on GCC 8.3.0 !
+        //               * error: ‘operator=’ should return a reference to ‘*this’ [-Werror=effc++]
+        //           @see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84364
+        // 
         template<typename T>
         FieldSetter& operator=(T&& value)
         {
@@ -38,6 +51,10 @@ class GelfMessage
             return *this;
         }
     };
+
+#ifdef __GNUC__
+RAPIDJSON_DIAG_POP
+#endif // __GNUC__
 
 public:
     GelfMessage() :

--- a/include/gelfcpp/GelfMessageBuilder.hpp
+++ b/include/gelfcpp/GelfMessageBuilder.hpp
@@ -44,10 +44,14 @@ namespace gelfcpp
  * builder(add_common_fields);
  * \endcode
  */
-struct GelfMessageBuilder
+class GelfMessageBuilder
 {
 public:
 #ifndef GELFCPP_DOXYGEN_RUNNING
+
+    GelfMessageBuilder()
+        : message_()
+    {}
 
     GelfMessageBuilder&& operator()(const std::string& message) &&
     {

--- a/include/gelfcpp/detail/Sender.hpp
+++ b/include/gelfcpp/detail/Sender.hpp
@@ -24,9 +24,10 @@ public:
     Sender(T& output) :
             output_(output) {}
 
-    void operator=(const GelfMessage& message)
+    Sender& operator=(const GelfMessage& message)
     {
         output_.Write(message);
+        return *this;
     }
 
 private:
@@ -48,9 +49,10 @@ public:
     Sender(T* output) :
             output_(output) {}
 
-    void operator=(const GelfMessage& message)
+    Sender& operator=(const GelfMessage& message)
     {
         output_->Write(message);
+        return *this;
     }
 
 private:
@@ -72,9 +74,10 @@ public:
     Sender(const std::shared_ptr<T>& output) :
             output_(output) {}
 
-    void operator=(const GelfMessage& message)
+    Sender& operator=(const GelfMessage& message)
     {
         output_->Write(message);
+        return *this;
     }
 
 private:
@@ -96,9 +99,10 @@ public:
     Sender(const std::unique_ptr<T, Deleter>& output) :
             output_(output) {}
 
-    void operator=(const GelfMessage& message)
+    Sender& operator=(const GelfMessage& message)
     {
         output_->Write(message);
+        return *this;
     }
 
 private:

--- a/include/gelfcpp/output/GelfUDPOutput.hpp
+++ b/include/gelfcpp/output/GelfUDPOutput.hpp
@@ -30,6 +30,10 @@ public:
      * \param port remote UDP port
      */
     GelfUDPOutput(const std::string& host, uint16_t port)
+        : serializer_()
+        , service_()
+        , endpoint_()
+        , socket_()
     {
         boost::asio::ip::udp::resolver resolver(service_);
         boost::asio::ip::udp::resolver::query query(host, std::to_string(port));

--- a/include/gelfcpp/output/GelfUDPOutput.hpp
+++ b/include/gelfcpp/output/GelfUDPOutput.hpp
@@ -2,6 +2,7 @@
 
 #include <gelfcpp/GelfMessage.hpp>
 #include <gelfcpp/detail/GelfSerializer.hpp>
+#include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/udp.hpp>
 #include <string>
 #include <cstdint>


### PR DESCRIPTION
We tend to compile using `-Werror=effc++`.

This PR fixes some issue related to using this compiler flag.

Also, there was a missing include in one of the headers.
(required when using Boost 1.67)